### PR TITLE
Fix for Rough Glass too bright when dispersion is enabled

### DIFF
--- a/src/yafraycore/mcintegrator.cc
+++ b/src/yafraycore/mcintegrator.cc
@@ -566,6 +566,7 @@ inline void mcIntegrator_t::recursiveRaytrace(renderState_t &state, diffRay_t &r
 			}
 
 			col += gcol * d_1;
+            if((bsdfs & BSDF_DISPERSIVE) && state.chromatic) col *= 0.5f; //Fix to avoid extra brightness in Rough Glass when dispersion is enabled, as I believe surface points are evaluated twice. Does it make sense?
             //if(col.maximum() > 1.f) Y_WARNING << col << " | " << d_1 << yendl;
 			state.rayDivision = oldDivision;
 			state.rayOffset = oldOffset;


### PR DESCRIPTION
When dispersion is enabled in Rough Glass, the material shows very bright. I believe that's caused by the material surface points to be evaluated twice and added.

For more information and images see:
http://www.yafaray.org/node/642

 Changes to be committed:
    modified:   src/yafraycore/mcintegrator.cc
