### PR TITLE
Add Shadow Bias and Min Ray Dist advanced parameters

### DIFF
--- a/include/core_api/scene.h
+++ b/include/core_api/scene.h
@@ -207,9 +207,11 @@ class YAFRAYCORE_EXPORT scene_t
 		std::vector<light_t *> lights;
 		volumeIntegrator_t *volIntegrator;
 
-        PFLOAT shadowBias;  //shadow bias to apply to shadows to avoid self-shadow artifacts
-        PFLOAT rayMinDist;  //ray minimum distance
+		PFLOAT shadowBias;  //shadow bias to apply to shadows to avoid self-shadow artifacts
+		bool shadowBiasAuto;  //enable automatic shadow bias calculation
 
+		PFLOAT rayMinDist;  //ray minimum distance
+		bool rayMinDistAuto;  //enable automatic ray minimum distance calculation
 
 	protected:
 

--- a/src/yafraycore/environment.cc
+++ b/src/yafraycore/environment.cc
@@ -634,6 +634,10 @@ bool renderEnvironment_t::setupScene(scene_t &scene, const paraMap_t &params, co
 	bool z_chan = false;
 	bool norm_z_chan = true;
 	bool drawParams = false;
+	bool adv_auto_shadow_bias_enabled=true;
+	float adv_shadow_bias_value=YAF_SHADOW_BIAS;
+	bool adv_auto_min_raydist_enabled=true;
+	float adv_min_raydist_value=MIN_RAYDIST;        
 	const std::string *custString = 0;
 	std::stringstream aaSettings;
 
@@ -695,6 +699,10 @@ bool renderEnvironment_t::setupScene(scene_t &scene, const paraMap_t &params, co
 	params.getParam("normalize_z_channel", norm_z_chan); // normalize values of z-buffer in range [0,1]
 	params.getParam("drawParams", drawParams);
 	params.getParam("customString", custString);
+	params.getParam("adv_auto_shadow_bias_enabled", adv_auto_shadow_bias_enabled);
+	params.getParam("adv_shadow_bias_value", adv_shadow_bias_value);
+	params.getParam("adv_auto_min_raydist_enabled", adv_auto_min_raydist_enabled);
+	params.getParam("adv_min_raydist_value", adv_min_raydist_value);
 
 	imageFilm_t *film = createImageFilm(params, output);
 
@@ -722,6 +730,10 @@ bool renderEnvironment_t::setupScene(scene_t &scene, const paraMap_t &params, co
 	scene.setAntialiasing(AA_samples, AA_passes, AA_inc_samples, AA_threshold);
 	scene.setNumThreads(nthreads);
 	if(backg) scene.setBackground(backg);
+	scene.shadowBiasAuto = adv_auto_shadow_bias_enabled;
+	scene.shadowBias = adv_shadow_bias_value;
+	scene.rayMinDistAuto = adv_auto_min_raydist_enabled;
+	scene.rayMinDist = adv_min_raydist_value;
 
 	return true;
 }

--- a/src/yafraycore/scene.cc
+++ b/src/yafraycore/scene.cc
@@ -785,14 +785,22 @@ bool scene_t::update()
 				"(" << sceneBound.a.x << ", " << sceneBound.a.y << ", " << sceneBound.a.z << "), (" <<
 				sceneBound.g.x << ", " << sceneBound.g.y << ", " << sceneBound.g.z << ")" << yendl;
 
-                //Automatic shadow bias calculation based on the original YAF_SHADOW_BIAS and an automatic correction based on the size of the scene. This is an empirical formula I just made up based on values of shadow bias that seem to avoid black self shadow artifacts in big scenes, probably will be improved in the future.
-                shadowBias = sceneBound.longX();
-                if(shadowBias < sceneBound.longY()) shadowBias=sceneBound.longY();
-                if(shadowBias < sceneBound.longZ()) shadowBias=sceneBound.longZ();
-                shadowBias = YAF_SHADOW_BIAS * 0.25f * shadowBias;
-                rayMinDist = 0.1f * shadowBias;
-               
-                Y_INFO << "Scene: total scene dimensions: X=" << sceneBound.longX() << ", Y=" << sceneBound.longY() << ", Z=" << sceneBound.longZ() << ", volume=" << sceneBound.vol() << ", calculated Shadow Bias=" << shadowBias << ", calculated Ray Min Dist=" << rayMinDist << yendl;
+				if(shadowBiasAuto)
+				{
+					//Automatic shadow bias calculation based on the original YAF_SHADOW_BIAS and an automatic correction based on the size of the scene. This is an empirical formula I just made up based on values of shadow bias that seem to avoid black self shadow artifacts in big scenes, probably will be improved in the future.
+					shadowBias = sceneBound.longX();
+					if(shadowBias < sceneBound.longY()) shadowBias=sceneBound.longY();
+					if(shadowBias < sceneBound.longZ()) shadowBias=sceneBound.longZ();
+					shadowBias = YAF_SHADOW_BIAS * 0.25f * shadowBias;
+				}
+				
+				if(rayMinDistAuto)
+				{
+					//Automatic Min Ray Dist calculation, based on the currently used Shadow Bias value. The factor 0.1 is based on the original ratio between YAF_SHADOW_BIAS (typically 0.0005) and MIN_RAYDIST (0.00005)
+					rayMinDist = 0.1f * shadowBias;
+				}
+
+				Y_INFO << "Scene: total scene dimensions: X=" << sceneBound.longX() << ", Y=" << sceneBound.longY() << ", Z=" << sceneBound.longZ() << ", volume=" << sceneBound.vol() << ", Shadow Bias=" << shadowBias << ", Ray Min Dist=" << rayMinDist << yendl;
 			}
 			else Y_WARNING << "Scene: Scene is empty..." << yendl;
 		}
@@ -828,14 +836,22 @@ bool scene_t::update()
 				"(" << sceneBound.a.x << ", " << sceneBound.a.y << ", " << sceneBound.a.z << "), (" <<
 				sceneBound.g.x << ", " << sceneBound.g.y << ", " << sceneBound.g.z << ")" << yendl;
 
-                //Automatic shadow bias calculation based on the original YAF_SHADOW_BIAS and an automatic correction based on the size of the scene. This is an empirical formula I just made up based on values of shadow bias that seem to avoid black self shadow artifacts in big scenes, probably will be improved in the future.
-                shadowBias = sceneBound.longX();
-                if(shadowBias < sceneBound.longY()) shadowBias=sceneBound.longY();
-                if(shadowBias < sceneBound.longZ()) shadowBias=sceneBound.longZ();
-                shadowBias = YAF_SHADOW_BIAS * 0.25f * shadowBias;
-                rayMinDist = 0.1f * shadowBias;
-               
-                Y_INFO << "Scene: total scene dimensions: X=" << sceneBound.longX() << ", Y=" << sceneBound.longY() << ", Z=" << sceneBound.longZ() << ", volume=" << sceneBound.vol() << ", calculated Shadow Bias=" << shadowBias << ", calculated Ray Min Dist=" << rayMinDist << yendl;
+				if(shadowBiasAuto)
+				{
+					//Automatic shadow bias calculation based on the original YAF_SHADOW_BIAS and an automatic correction based on the size of the scene. This is an empirical formula I just made up based on values of shadow bias that seem to avoid black self shadow artifacts in big scenes, probably will be improved in the future.
+					shadowBias = sceneBound.longX();
+					if(shadowBias < sceneBound.longY()) shadowBias=sceneBound.longY();
+					if(shadowBias < sceneBound.longZ()) shadowBias=sceneBound.longZ();
+					shadowBias = YAF_SHADOW_BIAS * 0.25f * shadowBias;
+				}
+				
+				if(rayMinDistAuto)
+				{
+					//Automatic Min Ray Dist calculation, based on the currently used Shadow Bias value. The factor 0.1 is based on the original ratio between YAF_SHADOW_BIAS (typically 0.0005) and MIN_RAYDIST (0.00005)
+					rayMinDist = 0.1f * shadowBias;
+				}
+
+				Y_INFO << "Scene: total scene dimensions: X=" << sceneBound.longX() << ", Y=" << sceneBound.longY() << ", Z=" << sceneBound.longZ() << ", volume=" << sceneBound.vol() << ", Shadow Bias=" << shadowBias << ", Ray Min Dist=" << rayMinDist << yendl;
 				
 			}
 			else Y_ERROR << "Scene: Scene is empty..." << yendl;


### PR DESCRIPTION
Although the new Automatic Shadow Bias and Min Ray Dist factors calculation introduced in the v0.1.99-beta2 improves the self shadowing artifacts in certain scenes, there are still certain scenes that could suffer self shadow problems. Also, the automatic calculation could introduce new artifacts in certain cases and scenes.

Creating a better algorithm to avoid self-shadow problems could be very time consuming, introduce new possible issues and artifacts and even increasing the memory usage and/or CPU usage.

Therefore, I'll go for a "hybrid" solution. By default, the Shadow Bias and Min Ray Dist factors will be automatically calculated, to keep the YafaRay spirit of "making things easy for the users". However, this modification introduces now new "advanced" parameters, so expert users could disable the automatic calculation and set manual Shadow Bias Factor and/or Min Ray Dist Factor.

The advantages of doing this:
- Avoiding new calculation algorithms that would affect everything and perhaps introduce new issues and potentially increasing CPU/RAM usage.
- For normal users the automatic calculation should be enough in most cases, making YafaRay easy enough to use.
- For expert users when encountering issues with self shadow or light leaking, they could fine tune these factors to achieve the desired results, even in scenes with strange meshes or special requirements.
- Being able to manually set these factors would also help with:
  - Terminator problems: "blocky" terminators in low-poly smooth meshes should be solved by subdividing the surfaces more, but if that's not possible, adjusting these factors could help.
  - Photon leaking: in some cases, photon leaking could happen depending on the scene and the requirements for the rendered result. Adjusting manually the Min Ray Dist could help solving those issues.
  - Any artifacts that could be caused by the automatic calculation could be solved by disabling it and setting the factor manually.

So, I believe this way, we keep YafaRay easy to use and, at the same time, we provide additional control for special fine tuning.

We will have a more complete now, as we can do any of the following:
- Have both Shadow Bias and Min Ray Dist calculated automatically (new behavior introduced in v0.1.99-beta2)
- Disable Shadow Bias Automatic calculation, setting a fixed factor of 0.0005. This would emulate the original YafaRay behavior previous to v0.1.99-beta2, where the Shadow Bias was 0.0005 and the Min Ray Dist was 0.00005.
- Disable Shadow Bias Automatic and/or Min Ray Dist Automatic and set different values. This would allow a new functionality that could be used (carefully) to fine tune the render of a specially difficult scene, where light leaks and/or shadow artifacts appear.

I also believe this solution is justified, especially when other ray tracers (even VRay) have similar factors available for the users.

 Changes to be committed:
    modified:   include/core_api/scene.h
    modified:   src/yafraycore/environment.cc
    modified:   src/yafraycore/scene.cc
