### PR TITLE
Fix for Final gather using background even if no IBL/caustic enabled

### DIFF
--- a/include/core_api/background.h
+++ b/include/core_api/background.h
@@ -21,6 +21,8 @@ class YAFRAYCORE_EXPORT background_t
 			\return the light source that reproduces background lighting, or NULL if background
 					shall only be sampled from BSDFs
 		*/
+		virtual bool hasIBL() { return false; }
+		virtual bool shootsCaustic() { return false; }
 		virtual ~background_t() {};
 };
 

--- a/src/backgrounds/darksky.cc
+++ b/src/backgrounds/darksky.cc
@@ -31,11 +31,13 @@ class darkSkyBackground_t: public background_t
 {
 	public:
 		darkSkyBackground_t(const point3d_t dir, float turb, float pwr, float skyBright, bool clamp, float av, float bv, float cv, float dv, float ev,
-							float altitude, bool night, float exp, bool genc, ColorSpaces cs);
+							float altitude, bool night, float exp, bool genc, ColorSpaces cs, bool ibl, bool with_caustic);
 		virtual color_t operator() (const ray_t &ray, renderState_t &state, bool filtered=false) const;
 		virtual color_t eval(const ray_t &ray, bool filtered=false) const;
 		virtual ~darkSkyBackground_t();
 		static background_t *factory(paraMap_t &,renderEnvironment_t &);
+		bool hasIBL() { return withIBL; }
+		bool shootsCaustic() { return shootCaustic; }
 		color_t getAttenuatedSunColor();
 
 	protected:
@@ -57,11 +59,14 @@ class darkSkyBackground_t: public background_t
 		ColorConv convert;
 		float alt;
 		bool nightSky;
+		bool withIBL;
+		bool shootCaustic;
+		bool shootDiffuse;
 };
 
 darkSkyBackground_t::darkSkyBackground_t(const point3d_t dir, float turb, float pwr, float skyBright, bool clamp,float av, float bv, float cv, float dv, float ev,
-										float altitude, bool night, float exp, bool genc, ColorSpaces cs):
-									   power(pwr * skyBright), skyBrightness(skyBright), convert(clamp, genc, cs, exp), alt(altitude), nightSky(night)
+										float altitude, bool night, float exp, bool genc, ColorSpaces cs, bool ibl, bool with_caustic):
+									   power(pwr * skyBright), skyBrightness(skyBright), convert(clamp, genc, cs, exp), alt(altitude), nightSky(night), withIBL(ibl), shootCaustic(with_caustic)
 {
 
 
@@ -310,7 +315,7 @@ background_t *darkSkyBackground_t::factory(paraMap_t &params,renderEnvironment_t
 	}
 
 	darkSkyBackground_t *darkSky = new darkSkyBackground_t(dir, turb, power, bright, clamp, av, bv, cv, dv, ev,
-																altitude, night, exp, gammaEnc, colorS);
+																altitude, night, exp, gammaEnc, colorS, bgl, caus);
 
 	if (add_sun && radToDeg(fAcos(dir.z)) < 100.0)
 	{

--- a/src/backgrounds/gradientback.cc
+++ b/src/backgrounds/gradientback.cc
@@ -31,18 +31,22 @@ __BEGIN_YAFRAY
 class gradientBackground_t: public background_t
 {
 	public:
-		gradientBackground_t(color_t gzcol, color_t ghcol, color_t szcol, color_t shcol);
+		gradientBackground_t(color_t gzcol, color_t ghcol, color_t szcol, color_t shcol, bool ibl, bool with_caustic);
 		virtual color_t operator() (const ray_t &ray, renderState_t &state, bool filtered=false) const;
 		virtual color_t eval(const ray_t &ray, bool filtered=false) const;
 		virtual ~gradientBackground_t();
 		static background_t *factory(paraMap_t &,renderEnvironment_t &);
+		bool hasIBL() { return withIBL; }
+		bool shootsCaustic() { return shootCaustic; }
 	protected:
-
 		color_t gzenith,  ghoriz, szenith, shoriz;
+		bool withIBL;
+		bool shootCaustic;
+		bool shootDiffuse;
 };
 
-gradientBackground_t::gradientBackground_t(color_t gzcol, color_t ghcol, color_t szcol, color_t shcol):
-gzenith(gzcol), ghoriz(ghcol), szenith(szcol), shoriz(shcol)
+gradientBackground_t::gradientBackground_t(color_t gzcol, color_t ghcol, color_t szcol, color_t shcol, bool ibl, bool with_caustic):
+gzenith(gzcol), ghoriz(ghcol), szenith(szcol), shoriz(shcol), withIBL(ibl), shootCaustic(with_caustic)
 {
 	// Empty
 }
@@ -94,7 +98,7 @@ background_t* gradientBackground_t::factory(paraMap_t &params,renderEnvironment_
 	params.getParam("ibl_samples", bglSam);
 	params.getParam("power", p);
 
-	background_t *gradBG = new gradientBackground_t(gzenith*p,  ghoriz*p, szenith*p, shoriz*p);
+	background_t *gradBG = new gradientBackground_t(gzenith*p,  ghoriz*p, szenith*p, shoriz*p, bgl, true);
 	
 	if(bgl)
 	{

--- a/src/backgrounds/sunsky.cc
+++ b/src/backgrounds/sunsky.cc
@@ -38,11 +38,13 @@ color_t ComputeAttenuatedSunlight(float theta, int turbidity);
 class sunskyBackground_t: public background_t
 {
 	public:
-		sunskyBackground_t(const point3d_t dir, float turb, float a_var, float b_var, float c_var, float d_var, float e_var, float pwr);
+		sunskyBackground_t(const point3d_t dir, float turb, float a_var, float b_var, float c_var, float d_var, float e_var, float pwr, bool ibl, bool with_caustic);
 		virtual color_t operator() (const ray_t &ray, renderState_t &state, bool filtered=false) const;
 		virtual color_t eval(const ray_t &ray, bool filtered=false) const;
 		virtual ~sunskyBackground_t();
 		static background_t *factory(paraMap_t &,renderEnvironment_t &);
+		bool hasIBL() { return withIBL; }
+		bool shootsCaustic() { return shootCaustic; }
 	protected:
 		color_t getSkyCol(const ray_t &ray) const;
 		vector3d_t sunDir;
@@ -54,9 +56,12 @@ class sunskyBackground_t: public background_t
 		double AngleBetween(double thetav, double phiv) const;
 		double PerezFunction(const double *lam, double theta, double gamma, double lvz) const;
 		float power;
+		bool withIBL;
+		bool shootCaustic;
+		bool shootDiffuse;
 };
 
-sunskyBackground_t::sunskyBackground_t(const point3d_t dir, float turb, float a_var, float b_var, float c_var, float d_var, float e_var, float pwr): power(pwr)
+sunskyBackground_t::sunskyBackground_t(const point3d_t dir, float turb, float a_var, float b_var, float c_var, float d_var, float e_var, float pwr, bool ibl, bool with_caustic): power(pwr), withIBL(ibl), shootCaustic(with_caustic)
 {
 	sunDir.set(dir.x, dir.y, dir.z);
 	sunDir.normalize();
@@ -227,7 +232,7 @@ background_t *sunskyBackground_t::factory(paraMap_t &params,renderEnvironment_t 
 	params.getParam("background_light", bgl);
 	params.getParam("light_samples", bgl_samples);
 
-	background_t *new_sunsky = new sunskyBackground_t(dir, turb, av, bv, cv, dv, ev, power);
+	background_t *new_sunsky = new sunskyBackground_t(dir, turb, av, bv, cv, dv, ev, power, bgl, true);
 
 	if(bgl)
 	{

--- a/src/integrators/pathtracer.cc
+++ b/src/integrators/pathtracer.cc
@@ -240,7 +240,7 @@ colorA_t pathIntegrator_t::integrate(renderState_t &state, diffRay_t &ray/*, sam
 
 					if(!scene->intersect(pRay, *hit2)) //hit background
 					{
-						if((caustic && background))
+						if((caustic && background && background->hasIBL() && background->shootsCaustic()))
 						{
 							pathCol += throughput * (*background)(pRay, state);
 						}

--- a/src/integrators/photonintegr.cc
+++ b/src/integrators/photonintegr.cc
@@ -737,7 +737,7 @@ color_t photonIntegrator_t::finalGathering(renderState_t &state, const surfacePo
 			
 			if(!did_hit) //hit background
 			{
-				 if(caustic && background)
+				 if(caustic && background && background->hasIBL() && background->shootsCaustic())
 				 {
 					pathCol += throughput * (*background)(pRay, state);
 				 }


### PR DESCRIPTION
In Photon Mapping and Path Tracing integrators, Final Gather was gathering the background even when IBL nor caustic were enabled in the background. This introduces undesired noise to the image from the background.

I've made changes to make sure Photon Mapping and Path Tracing _only_ use the background for caustics calculations when the background has IBL _and_ caustics enabled.

In the backgrounds like single color, gradient or SunSky1 where there is no parameter to enable caustic photons, I've set Final Gather to use the background just when IBL is enabled.

 Changes to be committed:
    modified:   include/core_api/background.h
    modified:   src/backgrounds/darksky.cc
    modified:   src/backgrounds/gradientback.cc
    modified:   src/backgrounds/sunsky.cc
    modified:   src/backgrounds/textureback.cc
    modified:   src/integrators/pathtracer.cc
    modified:   src/integrators/photonintegr.cc
