### PR TITLE
More advanced material visibility and shadow control

### DIFF
--- a/include/core_api/light.h
+++ b/include/core_api/light.h
@@ -67,6 +67,8 @@ class light_t
 		virtual void setBackground(background_t *bg) { background = bg; }
 		//! Enable/disable entire light source
 		virtual bool lightEnabled() const { return true;}
+		//! return true if the light should cast direct shadows
+		virtual bool castShadows() const { return true; }
 
 		light_t(): flags(LIGHT_NONE) {}
 		light_t(LIGHTF_t _flags): flags(_flags) {}

--- a/include/core_api/material.h
+++ b/include/core_api/material.h
@@ -70,6 +70,15 @@ struct pSample_t: public sample_t // << whats with the public?? structs inherit 
 	color_t color; //!< the new color after scattering, i.e. what will be lcol for next scatter.
 };
 
+enum visibility_t
+{
+	NORMAL_VISIBLE			= 0,
+	VISIBLE_NO_SHADOWS		= 1,
+	INVISIBLE_SHADOWS_ONLY	= 2,
+	INVISIBLE				= 3
+};
+
+
 class YAFRAYCORE_EXPORT material_t
 {
 	public:
@@ -105,7 +114,7 @@ class YAFRAYCORE_EXPORT material_t
 			used to trace transparent shadows. Note that in this case, initBSDF was NOT called before!
 		*/
 		virtual bool isTransparent() const { return false; }
-		virtual bool castShadows() const { return true; }
+		virtual visibility_t getVisibility() const { return NORMAL_VISIBLE; }
 
 		/*!	used for computing transparent shadows.	Default implementation returns black (i.e. solid shadow).
 			This is only used for shadow calculations and may only be called when isTransparent returned true.	*/

--- a/include/lights/arealight.h
+++ b/include/lights/arealight.h
@@ -11,7 +11,7 @@ class areaLight_t : public light_t
 {
 	public:
 		areaLight_t(const point3d_t &c, const vector3d_t &v1, const vector3d_t &v2,
-					const color_t &col, CFLOAT inte, int nsam, bool bLightEnabled=true);
+					const color_t &col, CFLOAT inte, int nsam, bool bLightEnabled=true, bool bCastShadows=true);
 		~areaLight_t();
 		virtual void init(scene_t &scene);
 		virtual color_t totalEnergy() const;
@@ -26,6 +26,7 @@ class areaLight_t : public light_t
 		virtual void emitPdf(const surfacePoint_t &sp, const vector3d_t &wi, float &areaPdf, float &dirPdf, float &cos_wo) const;
 		virtual int nSamples() const { return samples; }
 		virtual bool lightEnabled() const { return lLightEnabled;}
+		virtual bool castShadows() const { return lCastShadows; }
 		static light_t *factory(paraMap_t &params, renderEnvironment_t &render);
 	protected:
 		point3d_t corner, c2, c3, c4;
@@ -37,6 +38,7 @@ class areaLight_t : public light_t
 		float intensity; //!< ...this is actually redundant.
 		float area, invArea;
 		bool lLightEnabled; //!< enable/disable light
+		bool lCastShadows; //!< enable/disable if the light should cast direct shadows
 };
 
 __END_YAFRAY

--- a/include/lights/bgportallight.h
+++ b/include/lights/bgportallight.h
@@ -36,7 +36,7 @@ class background_t;
 class bgPortalLight_t : public light_t
 {
 	public:
-		bgPortalLight_t(unsigned int msh, int sampl, float pow, bool caus, bool diff, bool pOnly, bool bLightEnabled=true);
+		bgPortalLight_t(unsigned int msh, int sampl, float pow, bool caus, bool diff, bool pOnly, bool bLightEnabled=true, bool bCastShadows=true);
 		virtual ~bgPortalLight_t();
 		virtual void init(scene_t &scene);
 		virtual color_t totalEnergy() const;
@@ -54,6 +54,7 @@ class bgPortalLight_t : public light_t
 		virtual bool shootsCausticP() const { return shootCaustic; }
 		virtual bool shootsDiffuseP() const { return shootDiffuse; }
 		virtual bool lightEnabled() const { return lLightEnabled;}
+		virtual bool castShadows() const { return lCastShadows; }
 		static light_t *factory(paraMap_t &params, renderEnvironment_t &render);
 	protected:
 		void initIS();
@@ -74,6 +75,7 @@ class bgPortalLight_t : public light_t
 		bool shootDiffuse;
 		bool photonOnly;
 		bool lLightEnabled; //!< enable/disable light
+		bool lCastShadows; //!< enable/disable if the light should cast direct shadows
 };
 
 __END_YAFRAY

--- a/include/lights/meshlight.h
+++ b/include/lights/meshlight.h
@@ -35,7 +35,7 @@ class triKdTree_t;
 class meshLight_t : public light_t
 {
 	public:
-		meshLight_t(unsigned int msh, const color_t &col, int sampl, bool dbl_s=false, bool bLightEnabled=true);
+		meshLight_t(unsigned int msh, const color_t &col, int sampl, bool dbl_s=false, bool bLightEnabled=true, bool bCastShadows=true);
 		virtual ~meshLight_t();
 		virtual void init(scene_t &scene);
 		virtual color_t totalEnergy() const;
@@ -49,7 +49,8 @@ class meshLight_t : public light_t
 		virtual bool intersect(const ray_t &ray, PFLOAT &t, color_t &col, float &ipdf) const;
 		virtual float illumPdf(const surfacePoint_t &sp, const surfacePoint_t &sp_light) const;
 		virtual void emitPdf(const surfacePoint_t &sp, const vector3d_t &wi, float &areaPdf, float &dirPdf, float &cos_wo) const;
-		virtual bool lightEnabled() const { return lLightEnabled;}		
+		virtual bool lightEnabled() const { return lLightEnabled;}
+		virtual bool castShadows() const { return lCastShadows; }
 		static light_t *factory(paraMap_t &params, renderEnvironment_t &render);
 	protected:
 		void initIS();
@@ -67,6 +68,7 @@ class meshLight_t : public light_t
 		//debug stuff:
 		int *stats;
 		bool lLightEnabled; //!< enable/disable light
+		bool lCastShadows; //!< enable/disable if the light should cast direct shadows
 };
 
 __END_YAFRAY

--- a/include/materials/blendmat.h
+++ b/include/materials/blendmat.h
@@ -18,7 +18,7 @@ __BEGIN_YAFRAY
 class blendMat_t: public nodeMaterial_t
 {
 	public:
-		blendMat_t(const material_t *m1, const material_t *m2, float blendv, bool bCastShadows=true);
+		blendMat_t(const material_t *m1, const material_t *m2, float blendv, visibility_t eVisibility=NORMAL_VISIBLE);
 		virtual ~blendMat_t();
         virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wl, BSDF_t bsdfs)const;
@@ -26,7 +26,7 @@ class blendMat_t: public nodeMaterial_t
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		virtual float getMatIOR ()const;
 		virtual bool isTransparent() const;
-		virtual bool castShadows() const { return mCastShadows; }
+		virtual visibility_t getVisibility() const { return mVisibility; }
 		virtual color_t getTransparency(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const;
 		virtual color_t emit(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const;
 		virtual void getSpecular(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo,
@@ -45,7 +45,7 @@ class blendMat_t: public nodeMaterial_t
 		bool recalcBlend;
 		float blendedIOR;
 		mutable BSDF_t mat1Flags, mat2Flags;
-		bool mCastShadows; //!< enables/disables casting shadows. It should always be enabled except in specific cases.
+		visibility_t mVisibility ; //!< sets material visibility (Normal:visible, visible without shadows, invisible (shadows only) or totally invisible.
 	private:
 		void getBlendVal(const renderState_t &state, const surfacePoint_t &sp, float &val, float &ival) const;
 };

--- a/include/materials/maskmat.h
+++ b/include/materials/maskmat.h
@@ -12,13 +12,13 @@ class renderEnvironment_t;
 class maskMat_t: public nodeMaterial_t
 {
 	public:
-		maskMat_t(const material_t *m1, const material_t *m2, CFLOAT thresh, bool bCastShadows=true);
+		maskMat_t(const material_t *m1, const material_t *m2, CFLOAT thresh, visibility_t eVisibility=NORMAL_VISIBLE);
         virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
 		virtual bool isTransparent() const;
-		virtual bool castShadows() const { return mCastShadows; }
+		virtual visibility_t getVisibility() const { return mVisibility; }
 		virtual color_t getTransparency(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const;
 		virtual void getSpecular(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo,
 								 bool &reflect, bool &refract, vector3d_t *const dir, color_t *const col)const;
@@ -31,7 +31,7 @@ class maskMat_t: public nodeMaterial_t
 		const material_t *mat2;
 		shaderNode_t* mask;
 		CFLOAT threshold;
-		bool mCastShadows; //!< enables/disables casting shadows. It should always be enabled except in specific cases.
+		visibility_t mVisibility ; //!< sets material visibility (Normal:visible, visible without shadows, invisible (shadows only) or totally invisible.
 		//const texture_t *mask;
 };
 

--- a/include/materials/roughglass.h
+++ b/include/materials/roughglass.h
@@ -9,14 +9,14 @@ __BEGIN_YAFRAY
 class roughGlassMat_t: public nodeMaterial_t
 {
 	public:
-		roughGlassMat_t(float IOR, color_t filtC, const color_t &srcol, bool fakeS, float alpha, float disp_pow, bool bCastShadows=true);
+		roughGlassMat_t(float IOR, color_t filtC, const color_t &srcol, bool fakeS, float alpha, float disp_pow, visibility_t eVisibility=NORMAL_VISIBLE);
         virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, unsigned int &bsdfTypes) const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W) const;
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t *const dir, color_t &tcol, sample_t &s, float *const W)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs) const { return 0.f; }
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs) const { return 0.f; }
 		virtual bool isTransparent() const { return fakeShadow; }
-		virtual bool castShadows() const { return mCastShadows; }
+		virtual visibility_t getVisibility() const { return mVisibility; }
 		virtual color_t getTransparency(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo) const;
 		virtual float getAlpha(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo) const;
 		virtual float getMatIOR() const;
@@ -36,7 +36,7 @@ class roughGlassMat_t: public nodeMaterial_t
 		bool absorb, disperse, fakeShadow;
         float dispersion_power;
 		float CauchyA, CauchyB;
-		bool mCastShadows; //!< enables/disables casting shadows. It should always be enabled except in specific cases.
+		visibility_t mVisibility ; //!< sets material visibility (Normal:visible, visible without shadows, invisible (shadows only) or totally invisible.
 };
 
 __END_YAFRAY

--- a/include/materials/shinydiff.h
+++ b/include/materials/shinydiff.h
@@ -24,14 +24,14 @@ __BEGIN_YAFRAY
 class shinyDiffuseMat_t: public nodeMaterial_t
 {
     public:
-        shinyDiffuseMat_t(const color_t &diffuseColor, const color_t &mirrorColor, float diffuseStrength, float transparencyStrength=0.0, float translucencyStrength=0.0, float mirrorStrength=0.0, float emitStrength=0.0, float transmitFilterStrength=1.0, bool bCastShadows=true);
+        shinyDiffuseMat_t(const color_t &diffuseColor, const color_t &mirrorColor, float diffuseStrength, float transparencyStrength=0.0, float translucencyStrength=0.0, float mirrorStrength=0.0, float emitStrength=0.0, float transmitFilterStrength=1.0, visibility_t eVisibility=NORMAL_VISIBLE);
         virtual ~shinyDiffuseMat_t();
         virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, BSDF_t &bsdfTypes)const;
         virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wl, BSDF_t bsdfs)const;
         virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
         virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const;
         virtual bool isTransparent() const { return mIsTransparent; }
-        virtual bool castShadows() const { return mCastShadows; }
+        virtual visibility_t getVisibility() const { return mVisibility; }
         virtual color_t getTransparency(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const;
         virtual color_t emit(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const; // { return emitCol; }
         virtual void getSpecular(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, bool &reflect, bool &refract, vector3d_t *const dir, color_t *const col)const;
@@ -88,7 +88,7 @@ class shinyDiffuseMat_t: public nodeMaterial_t
         float mOrenNayar_B;                 //!< Oren Nayar B coefficient
 
         int nBSDF;
-        bool mCastShadows;                  //!< enables/disables casting shadows. It should always be enabled except in specific cases.
+        visibility_t mVisibility ;          //!< sets material visibility (Normal:visible, visible without shadows, invisible (shadows only) or totally invisible.
 
         BSDF_t cFlags[4];                   //!< list the BSDF components that are present
         int cIndex[4];                      //!< list the index of the BSDF components (0=specular reflection, 1=specular transparency, 2=translucency, 3=diffuse reflection)

--- a/include/yafray_constants.h
+++ b/include/yafray_constants.h
@@ -5,7 +5,7 @@
 #define __END_YAFRAY }
 
 #define PACKAGE "YafaRay"
-#define VERSION "0.1.99-beta4"
+#define VERSION "0.1.99-beta4c"
 
 #if (__GNUC__ > 3)
         #define GCC_HASCLASSVISIBILITY

--- a/src/lights/arealight.cc
+++ b/src/lights/arealight.cc
@@ -31,8 +31,8 @@ __BEGIN_YAFRAY
 //int hit_t1=0, hit_t2=0;
 
 areaLight_t::areaLight_t(const point3d_t &c, const vector3d_t &v1, const vector3d_t &v2,
-				const color_t &col,CFLOAT inte, int nsam, bool bLightEnabled):
-				corner(c), toX(v1), toY(v2), samples(nsam), intensity(inte), lLightEnabled(bLightEnabled)
+				const color_t &col,CFLOAT inte, int nsam, bool bLightEnabled, bool bCastShadows):
+				corner(c), toX(v1), toY(v2), samples(nsam), intensity(inte), lLightEnabled(bLightEnabled), lCastShadows(bCastShadows)
 {
 	fnormal = toY^toX; //f normal is "flipped" normal direction...
 	color = col*inte * M_PI;
@@ -178,6 +178,7 @@ light_t* areaLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	int samples = 4;
 	int object = 0;
 	bool lightEnabled = true;
+	bool castShadows = true;
 
 	params.getParam("corner",corner);
 	params.getParam("point1",p1);
@@ -187,8 +188,9 @@ light_t* areaLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	params.getParam("samples",samples);
 	params.getParam("object", object);
 	params.getParam("light_enabled", lightEnabled);
+	params.getParam("cast_shadows", castShadows);
 
-	areaLight_t *light = new areaLight_t(corner, p1-corner, p2-corner, color, power, samples, lightEnabled);
+	areaLight_t *light = new areaLight_t(corner, p1-corner, p2-corner, color, power, samples, lightEnabled, castShadows);
 	light->objID = (unsigned int)object;
 	return light;
 }

--- a/src/lights/bgportallight.cc
+++ b/src/lights/bgportallight.cc
@@ -29,8 +29,8 @@
 
 __BEGIN_YAFRAY
 
-bgPortalLight_t::bgPortalLight_t(unsigned int msh, int sampl, float pow, bool caus, bool diff, bool pOnly, bool bLightEnabled):
-	objID(msh), samples(sampl), power(pow), tree(0), shootCaustic(caus), shootDiffuse(diff), photonOnly(pOnly), lLightEnabled(bLightEnabled)
+bgPortalLight_t::bgPortalLight_t(unsigned int msh, int sampl, float pow, bool caus, bool diff, bool pOnly, bool bLightEnabled, bool bCastShadows):
+	objID(msh), samples(sampl), power(pow), tree(0), shootCaustic(caus), shootDiffuse(diff), photonOnly(pOnly), lLightEnabled(bLightEnabled), lCastShadows(bCastShadows)
 {
 	mesh = NULL;
 	aPdf = 0.f;
@@ -235,6 +235,7 @@ light_t* bgPortalLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	bool diff = true;
 	bool ponly = false;
 	bool lightEnabled = true;
+	bool castShadows = true;
 
 	params.getParam("object", object);
 	params.getParam("samples", samples);
@@ -243,7 +244,8 @@ light_t* bgPortalLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	params.getParam("with_diffuse", diff);
 	params.getParam("photon_only", ponly);
 	params.getParam("light_enabled", lightEnabled);
+	params.getParam("cast_shadows", castShadows);
 	
-	return new bgPortalLight_t(object, samples, pow, caus, diff, ponly, lightEnabled);
+	return new bgPortalLight_t(object, samples, pow, caus, diff, ponly, lightEnabled, castShadows);
 }
 __END_YAFRAY

--- a/src/lights/directional.cc
+++ b/src/lights/directional.cc
@@ -28,7 +28,7 @@ __BEGIN_YAFRAY
 class directionalLight_t : public light_t
 {
   public:
-	directionalLight_t(const point3d_t &pos, vector3d_t dir, const color_t &col, CFLOAT inte, bool inf, float rad, bool bLightEnabled);
+	directionalLight_t(const point3d_t &pos, vector3d_t dir, const color_t &col, CFLOAT inte, bool inf, float rad, bool bLightEnabled=true, bool bCastShadows=true);
 	virtual void init(scene_t &scene);
 	virtual color_t totalEnergy() const { return color * radius*radius * M_PI; }
 	virtual color_t emitPhoton(float s1, float s2, float s3, float s4, ray_t &ray, float &ipdf) const;
@@ -37,6 +37,7 @@ class directionalLight_t : public light_t
 	virtual bool illumSample(const surfacePoint_t &sp, lSample_t &s, ray_t &wi) const;
 	virtual bool illuminate(const surfacePoint_t &sp, color_t &col, ray_t &wi) const;
 	virtual bool lightEnabled() const { return lLightEnabled;}
+	virtual bool castShadows() const { return lCastShadows; }
 	static light_t *factory(paraMap_t &params, renderEnvironment_t &render);
   protected:
 	point3d_t position;
@@ -49,10 +50,11 @@ class directionalLight_t : public light_t
 	bool infinite;
 	int majorAxis; //!< the largest component of direction
 	bool lLightEnabled; //!< enable/disable light
+	bool lCastShadows; //!< enable/disable if the light should cast direct shadows
 };
 
-directionalLight_t::directionalLight_t(const point3d_t &pos, vector3d_t dir, const color_t &col, CFLOAT inte, bool inf, float rad, bool bLightEnabled):
-	light_t(LIGHT_DIRACDIR), position(pos), direction(dir), radius(rad), infinite(inf), lLightEnabled(bLightEnabled)
+directionalLight_t::directionalLight_t(const point3d_t &pos, vector3d_t dir, const color_t &col, CFLOAT inte, bool inf, float rad, bool bLightEnabled, bool bCastShadows):
+	light_t(LIGHT_DIRACDIR), position(pos), direction(dir), radius(rad), infinite(inf), lLightEnabled(bLightEnabled), lCastShadows(bCastShadows)
 {
 	color = col * inte;
 	intensity = color.energy();
@@ -141,12 +143,14 @@ light_t *directionalLight_t::factory(paraMap_t &params,renderEnvironment_t &rend
 	float rad = 1.0;
 	bool inf = true;
 	bool lightEnabled = true;
+	bool castShadows = true;
 	
 	params.getParam("direction",dir);
 	params.getParam("color",color);
 	params.getParam("power",power);
 	params.getParam("infinite", inf);
 	params.getParam("light_enabled", lightEnabled);
+	params.getParam("cast_shadows", castShadows);
 	
 	if(!inf)
 	{
@@ -157,7 +161,7 @@ light_t *directionalLight_t::factory(paraMap_t &params,renderEnvironment_t &rend
 		params.getParam("radius",rad);
 	}
 
-	return new directionalLight_t(from, vector3d_t(dir.x, dir.y, dir.z), color, power, inf, rad, lightEnabled);
+	return new directionalLight_t(from, vector3d_t(dir.x, dir.y, dir.z), color, power, inf, rad, lightEnabled, castShadows);
 }
 
 extern "C"

--- a/src/lights/iesLight.cc
+++ b/src/lights/iesLight.cc
@@ -32,7 +32,7 @@ class iesLight_t : public light_t
 {
 	public:
 
-		iesLight_t(const point3d_t &from, const point3d_t &to, const color_t &col, CFLOAT power, const std::string iesFile, int smpls, bool sSha, float ang, bool bLightEnabled);
+		iesLight_t(const point3d_t &from, const point3d_t &to, const color_t &col, CFLOAT power, const std::string iesFile, int smpls, bool sSha, float ang, bool bLightEnabled=true, bool bCastShadows=true);
 
 		virtual color_t totalEnergy() const { return color * totEnergy;};
 		virtual int nSamples() const { return samples; };
@@ -51,6 +51,7 @@ class iesLight_t : public light_t
 		
 		bool isIESOk(){ return IESOk; };
 		virtual bool lightEnabled() const { return lLightEnabled;}
+		virtual bool castShadows() const { return lCastShadows; }
 		
 		static light_t *factory(paraMap_t &params, renderEnvironment_t &render);
 		
@@ -75,10 +76,11 @@ class iesLight_t : public light_t
 		
 		bool IESOk;
 		bool lLightEnabled; //!< enable/disable light
+		bool lCastShadows; //!< enable/disable if the light should cast direct shadows
 };
 
-iesLight_t::iesLight_t(const point3d_t &from, const point3d_t &to, const color_t &col, CFLOAT power, const std::string iesFile, int smpls, bool sSha, float ang, bool bLightEnabled):
-	light_t(LIGHT_SINGULAR), position(from), samples(smpls), softShadow(sSha), lLightEnabled(bLightEnabled)
+iesLight_t::iesLight_t(const point3d_t &from, const point3d_t &to, const color_t &col, CFLOAT power, const std::string iesFile, int smpls, bool sSha, float ang, bool bLightEnabled, bool bCastShadows):
+	light_t(LIGHT_SINGULAR), position(from), samples(smpls), softShadow(sSha), lLightEnabled(bLightEnabled), lCastShadows(bCastShadows)
 {
 	iesData = new IESData_t();
 	
@@ -242,6 +244,7 @@ light_t *iesLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	bool sSha = false;
 	float ang = 180.f; //full hemi
 	bool lightEnabled = true;
+	bool castShadows = true;
 
 	params.getParam("from",from);
 	params.getParam("to",to);
@@ -252,8 +255,9 @@ light_t *iesLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	params.getParam("soft_shadows", sSha);
 	params.getParam("cone_angle", ang);
 	params.getParam("light_enabled", lightEnabled);
+	params.getParam("cast_shadows", castShadows);
 
-	iesLight_t* light = new iesLight_t(from, to, color, power, file, sam, sSha, ang, lightEnabled);
+	iesLight_t* light = new iesLight_t(from, to, color, power, file, sam, sSha, ang, lightEnabled, castShadows);
 
 	if (!light->isIESOk())
 	{

--- a/src/lights/meshlight.cc
+++ b/src/lights/meshlight.cc
@@ -29,8 +29,8 @@
 
 __BEGIN_YAFRAY
 
-meshLight_t::meshLight_t(unsigned int msh, const color_t &col, int sampl, bool dbl_s, bool bLightEnabled):
-	objID(msh), doubleSided(dbl_s), color(col), samples(sampl), tree(0), lLightEnabled(bLightEnabled)
+meshLight_t::meshLight_t(unsigned int msh, const color_t &col, int sampl, bool dbl_s, bool bLightEnabled, bool bCastShadows):
+	objID(msh), doubleSided(dbl_s), color(col), samples(sampl), tree(0), lLightEnabled(bLightEnabled), lCastShadows(bCastShadows)
 {
 	mesh = 0;
 	//initIS();
@@ -226,6 +226,7 @@ light_t* meshLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	int samples = 4;
 	int object = 0;
 	bool lightEnabled = true;
+	bool castShadows = true;
 
 	params.getParam("object", object);
 	params.getParam("color", color);
@@ -233,7 +234,8 @@ light_t* meshLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	params.getParam("samples", samples);
 	params.getParam("double_sided", doubleS);
 	params.getParam("light_enabled", lightEnabled);
+	params.getParam("cast_shadows", castShadows);
 
-	return new meshLight_t(object, color*(CFLOAT)power*M_PI, samples, doubleS, lightEnabled);
+	return new meshLight_t(object, color*(CFLOAT)power*M_PI, samples, doubleS, lightEnabled, castShadows);
 }
 __END_YAFRAY

--- a/src/lights/pointlight.cc
+++ b/src/lights/pointlight.cc
@@ -28,7 +28,7 @@ __BEGIN_YAFRAY
 class pointLight_t : public light_t
 {
   public:
-	pointLight_t(const point3d_t &pos, const color_t &col, CFLOAT inte, bool bLightEnabled);
+	pointLight_t(const point3d_t &pos, const color_t &col, CFLOAT inte, bool bLightEnabled=true, bool bCastShadows=true);
 	virtual color_t totalEnergy() const { return color * 4.0f * M_PI; }
 	virtual color_t emitPhoton(float s1, float s2, float s3, float s4, ray_t &ray, float &ipdf) const;
 	virtual color_t emitSample(vector3d_t &wo, lSample_t &s) const;
@@ -37,16 +37,18 @@ class pointLight_t : public light_t
 	virtual bool illuminate(const surfacePoint_t &sp, color_t &col, ray_t &wi) const;
 	virtual void emitPdf(const surfacePoint_t &sp, const vector3d_t &wo, float &areaPdf, float &dirPdf, float &cos_wo) const;
 	virtual bool lightEnabled() const { return lLightEnabled;}
+	virtual bool castShadows() const { return lCastShadows; }
 	static light_t *factory(paraMap_t &params, renderEnvironment_t &render);
   protected:
 	point3d_t position;
 	color_t color;
 	float intensity;
-	bool lLightEnabled; //!< enable/disable light	
+	bool lLightEnabled; //!< enable/disable light
+	bool lCastShadows; //!< enable/disable if the light should cast direct shadows
 };
 
-pointLight_t::pointLight_t(const point3d_t &pos, const color_t &col, CFLOAT inte, bool bLightEnabled):
-	light_t(LIGHT_SINGULAR), position(pos), lLightEnabled(bLightEnabled)
+pointLight_t::pointLight_t(const point3d_t &pos, const color_t &col, CFLOAT inte, bool bLightEnabled, bool bCastShadows):
+	light_t(LIGHT_SINGULAR), position(pos), lLightEnabled(bLightEnabled), lCastShadows(bCastShadows)
 {
 	color = col * inte;
 	intensity = color.energy();
@@ -120,13 +122,15 @@ light_t *pointLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	color_t color(1.0);
 	CFLOAT power = 1.0;
 	bool lightEnabled = true;
+	bool castShadows = true;
 
 	params.getParam("from",from);
 	params.getParam("color",color);
 	params.getParam("power",power);
 	params.getParam("light_enabled", lightEnabled);
+	params.getParam("cast_shadows", castShadows);
 
-	return new pointLight_t(from, color, power, lightEnabled);
+	return new pointLight_t(from, color, power, lightEnabled, castShadows);
 }
 
 extern "C"

--- a/src/lights/spherelight.cc
+++ b/src/lights/spherelight.cc
@@ -37,7 +37,7 @@ __BEGIN_YAFRAY
 class sphereLight_t : public light_t
 {
 	public:
-		sphereLight_t(const point3d_t &c, PFLOAT rad, const color_t &col, CFLOAT inte, int nsam, bool bLightEnabled);
+		sphereLight_t(const point3d_t &c, PFLOAT rad, const color_t &col, CFLOAT inte, int nsam, bool bLightEnabled=true, bool bCastShadows=true);
 		~sphereLight_t();
 		virtual void init(scene_t &scene);
 		virtual color_t totalEnergy() const;
@@ -52,6 +52,7 @@ class sphereLight_t : public light_t
 		virtual void emitPdf(const surfacePoint_t &sp, const vector3d_t &wo, float &areaPdf, float &dirPdf, float &cos_wo) const;
 		virtual int nSamples() const { return samples; }
 		virtual bool lightEnabled() const { return lLightEnabled;}
+		virtual bool castShadows() const { return lCastShadows; }
 		static light_t *factory(paraMap_t &params, renderEnvironment_t &render);
 	protected:
 		point3d_t center;
@@ -61,10 +62,11 @@ class sphereLight_t : public light_t
 		unsigned int objID;
 		float area, invArea;
 		bool lLightEnabled; //!< enable/disable light
+		bool lCastShadows; //!< enable/disable if the light should cast direct shadows
 };
 
-sphereLight_t::sphereLight_t(const point3d_t &c, PFLOAT rad, const color_t &col, CFLOAT inte, int nsam, bool bLightEnabled):
-	center(c), radius(rad), samples(nsam), lLightEnabled(bLightEnabled)
+sphereLight_t::sphereLight_t(const point3d_t &c, PFLOAT rad, const color_t &col, CFLOAT inte, int nsam, bool bLightEnabled, bool bCastShadows):
+	center(c), radius(rad), samples(nsam), lLightEnabled(bLightEnabled), lCastShadows(bCastShadows)
 {
 	color = col*inte;
 	square_radius = radius*radius;
@@ -202,6 +204,7 @@ light_t *sphereLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	int samples = 4;
 	int object = 0;
 	bool lightEnabled = true;
+	bool castShadows = true;
 
 	params.getParam("from",from);
 	params.getParam("color",color);
@@ -210,8 +213,9 @@ light_t *sphereLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	params.getParam("samples",samples);
 	params.getParam("object", object);
 	params.getParam("light_enabled", lightEnabled);
+	params.getParam("cast_shadows", castShadows);
 	
-	sphereLight_t *light = new sphereLight_t(from, radius, color, power, samples, lightEnabled);
+	sphereLight_t *light = new sphereLight_t(from, radius, color, power, samples, lightEnabled, castShadows);
 	light->objID = (unsigned int)object;
 	return light;
 }

--- a/src/lights/spotlight.cc
+++ b/src/lights/spotlight.cc
@@ -28,7 +28,7 @@ __BEGIN_YAFRAY
 class spotLight_t : public light_t
 {
 	public:
-		spotLight_t(const point3d_t &from, const point3d_t &to, const color_t &col, CFLOAT power, PFLOAT angle, PFLOAT falloff, bool ponly, bool sSha, int smpl, float ssfuzzy, bool bLightEnabled);
+		spotLight_t(const point3d_t &from, const point3d_t &to, const color_t &col, CFLOAT power, PFLOAT angle, PFLOAT falloff, bool ponly, bool sSha, int smpl, float ssfuzzy, bool bLightEnabled=true, bool bCastShadows=true);
 		virtual ~spotLight_t();
 		virtual color_t totalEnergy() const;
 		virtual color_t emitPhoton(float s1, float s2, float s3, float s4, ray_t &ray, float &ipdf) const;
@@ -40,6 +40,7 @@ class spotLight_t : public light_t
 		virtual bool canIntersect() const{ return softShadows; }
 		virtual bool intersect(const ray_t &ray, float &t, color_t &col, float &ipdf) const;
 		virtual bool lightEnabled() const { return lLightEnabled;}
+		virtual bool castShadows() const { return lCastShadows; }
 		static light_t *factory(paraMap_t &params, renderEnvironment_t &render);
 
 		virtual int nSamples() const { return samples; };
@@ -60,10 +61,11 @@ class spotLight_t : public light_t
 		float shadowFuzzy;
 		int samples;
 		bool lLightEnabled; //!< enable/disable light
+		bool lCastShadows; //!< enable/disable if the light should cast direct shadows
 };
 
-spotLight_t::spotLight_t(const point3d_t &from, const point3d_t &to, const color_t &col, CFLOAT power, PFLOAT angle, PFLOAT falloff, bool ponly, bool sSha, int smpl, float ssfuzzy, bool bLightEnabled):
-	light_t(LIGHT_SINGULAR), position(from), intensity(power), photonOnly(ponly), softShadows(sSha), shadowFuzzy(ssfuzzy), samples(smpl), lLightEnabled(bLightEnabled)
+spotLight_t::spotLight_t(const point3d_t &from, const point3d_t &to, const color_t &col, CFLOAT power, PFLOAT angle, PFLOAT falloff, bool ponly, bool sSha, int smpl, float ssfuzzy, bool bLightEnabled, bool bCastShadows):
+	light_t(LIGHT_SINGULAR), position(from), intensity(power), photonOnly(ponly), softShadows(sSha), shadowFuzzy(ssfuzzy), samples(smpl), lLightEnabled(bLightEnabled), lCastShadows(bCastShadows)
 {
 	ndir = (from - to).normalize();
 	dir = -ndir;
@@ -293,6 +295,7 @@ light_t *spotLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	int smpl = 8;
 	float ssfuzzy = 1.f;
 	bool lightEnabled = true;
+	bool castShadows = true;
 
 	params.getParam("from",from);
 	params.getParam("to",to);
@@ -305,8 +308,9 @@ light_t *spotLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	params.getParam("shadowFuzzyness",ssfuzzy);
 	params.getParam("samples",smpl);
 	params.getParam("light_enabled", lightEnabled);
+	params.getParam("cast_shadows", castShadows);
 	
-	return new spotLight_t(from, to, color, power, angle, falloff, pOnly, softShadows, smpl, ssfuzzy, lightEnabled);
+	return new spotLight_t(from, to, color, power, angle, falloff, pOnly, softShadows, smpl, ssfuzzy, lightEnabled, castShadows);
 }
 
 

--- a/src/lights/sunlight.cc
+++ b/src/lights/sunlight.cc
@@ -27,7 +27,7 @@ __BEGIN_YAFRAY
 class sunLight_t : public light_t
 {
   public:
-	sunLight_t(vector3d_t dir, const color_t &col, CFLOAT inte, float angle, int nSamples, bool bLightEnabled);
+	sunLight_t(vector3d_t dir, const color_t &col, CFLOAT inte, float angle, int nSamples, bool bLightEnabled=true, bool bCastShadows=true);
 	virtual void init(scene_t &scene);
 	virtual color_t totalEnergy() const { return color * ePdf; }
 	virtual color_t emitPhoton(float s1, float s2, float s3, float s4, ray_t &ray, float &ipdf) const;
@@ -38,6 +38,7 @@ class sunLight_t : public light_t
 	virtual bool intersect(const ray_t &ray, PFLOAT &t, color_t &col, float &ipdf) const;
 	virtual int nSamples() const { return samples; }
 	virtual bool lightEnabled() const { return lLightEnabled;}
+	virtual bool castShadows() const { return lCastShadows; }
 	static light_t *factory(paraMap_t &params, renderEnvironment_t &render);
   protected:
 	point3d_t worldCenter;
@@ -49,10 +50,11 @@ class sunLight_t : public light_t
 	float worldRadius;
 	float ePdf;
 	bool lLightEnabled; //!< enable/disable light
+	bool lCastShadows; //!< enable/disable if the light should cast direct shadows
 };
 
-sunLight_t::sunLight_t(vector3d_t dir, const color_t &col, CFLOAT inte, float angle, int nSamples, bool bLightEnabled):
-	direction(dir), samples(nSamples), lLightEnabled(bLightEnabled)
+sunLight_t::sunLight_t(vector3d_t dir, const color_t &col, CFLOAT inte, float angle, int nSamples, bool bLightEnabled, bool bCastShadows):
+	direction(dir), samples(nSamples), lLightEnabled(bLightEnabled), lCastShadows(bCastShadows)
 {
 	color = col * inte;
 	direction.normalize();
@@ -122,6 +124,7 @@ light_t *sunLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	float angle = 0.27; //angular (half-)size of the real sun;
 	int samples = 4;
 	bool lightEnabled = true;
+	bool castShadows = true;
 
 	params.getParam("direction",dir);
 	params.getParam("color",color);
@@ -129,8 +132,9 @@ light_t *sunLight_t::factory(paraMap_t &params,renderEnvironment_t &render)
 	params.getParam("angle",angle);
 	params.getParam("samples",samples);
 	params.getParam("light_enabled", lightEnabled);
+	params.getParam("cast_shadows", castShadows);
 
-	return new sunLight_t(vector3d_t(dir.x, dir.y, dir.z), color, power, angle, samples, lightEnabled);
+	return new sunLight_t(vector3d_t(dir.x, dir.y, dir.z), color, power, angle, samples, lightEnabled, castShadows);
 }
 
 extern "C"

--- a/src/materials/blend.cc
+++ b/src/materials/blend.cc
@@ -30,8 +30,8 @@ __BEGIN_YAFRAY
 
 #define addPdf(p1, p2) (p1*ival + p2*val)
 
-blendMat_t::blendMat_t(const material_t *m1, const material_t *m2, float bval, bool bCastShadows):
-	mat1(m1), mat2(m2), blendS(0), mCastShadows(bCastShadows)
+blendMat_t::blendMat_t(const material_t *m1, const material_t *m2, float bval, visibility_t eVisibility):
+	mat1(m1), mat2(m2), blendS(0), mVisibility(eVisibility)
 {
 	bsdfFlags = mat1->getFlags() | mat2->getFlags();
 	mmem1 = mat1->getReqMem();
@@ -389,18 +389,25 @@ material_t* blendMat_t::factory(paraMap_t &params, std::list<paraMap_t> &eparams
 	const std::string *name = 0;
 	const material_t *m1=0, *m2=0;
 	double blend_val = 0.5;
-	bool bCastShadows=true;
+	std::string sVisibility = "normal";
+	visibility_t visibility = NORMAL_VISIBLE;
 	
 	if(! params.getParam("material1", name) ) return 0;
 	m1 = env.getMaterial(*name);
 	if(! params.getParam("material2", name) ) return 0;
 	m2 = env.getMaterial(*name);
 	params.getParam("blend_value", blend_val);
-	params.getParam("cast_shadows",     bCastShadows);
+	params.getParam("visibility", sVisibility);
+	
+	if(sVisibility == "normal") visibility = NORMAL_VISIBLE;
+	else if(sVisibility == "no_shadows") visibility = VISIBLE_NO_SHADOWS;
+	else if(sVisibility == "shadow_only") visibility = INVISIBLE_SHADOWS_ONLY;
+	else if(sVisibility == "invisible") visibility = INVISIBLE;
+	else visibility = NORMAL_VISIBLE;
 	
 	if(m1==0 || m2==0 ) return 0;
 	
-	blendMat_t *mat = new blendMat_t(m1, m2, blend_val, bCastShadows);
+	blendMat_t *mat = new blendMat_t(m1, m2, blend_val, visibility);
 	
 	std::vector<shaderNode_t *> roots;
 	if(mat->loadNodes(eparams, env))

--- a/src/materials/glass.cc
+++ b/src/materials/glass.cc
@@ -28,13 +28,13 @@ __BEGIN_YAFRAY
 class glassMat_t: public nodeMaterial_t
 {
 	public:
-		glassMat_t(float IOR, color_t filtC, const color_t &srcol, double disp_pow, bool fakeS, bool bCastShadows);
+		glassMat_t(float IOR, color_t filtC, const color_t &srcol, double disp_pow, bool fakeS, visibility_t eVisibility=NORMAL_VISIBLE);
         virtual void initBSDF(const renderState_t &state, surfacePoint_t &sp, unsigned int &bsdfTypes)const;
 		virtual color_t eval(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wl, BSDF_t bsdfs)const {return color_t(0.0);}
 		virtual color_t sample(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, vector3d_t &wi, sample_t &s, float &W)const;
 		virtual float pdf(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo, const vector3d_t &wi, BSDF_t bsdfs)const {return 0.f;}
 		virtual bool isTransparent() const { return fakeShadow; }
-		virtual bool castShadows() const { return mCastShadows; }
+		virtual visibility_t getVisibility() const { return mVisibility; }
 		virtual color_t getTransparency(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const;
 		virtual CFLOAT getAlpha(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo)const;
 		virtual void getSpecular(const renderState_t &state, const surfacePoint_t &sp, const vector3d_t &wo,
@@ -53,12 +53,12 @@ class glassMat_t: public nodeMaterial_t
 		BSDF_t tmFlags;
 		PFLOAT dispersion_power;
 		PFLOAT CauchyA, CauchyB;
-		bool mCastShadows; //!< enables/disables casting shadows. It should always be enabled except in specific cases.
+		visibility_t mVisibility ; //!< sets material visibility (Normal:visible, visible without shadows, invisible (shadows only) or totally invisible.
 };
 
-glassMat_t::glassMat_t(float IOR, color_t filtC, const color_t &srcol, double disp_pow, bool fakeS, bool bCastShadows):
+glassMat_t::glassMat_t(float IOR, color_t filtC, const color_t &srcol, double disp_pow, bool fakeS, visibility_t eVisibility):
 		bumpS(0), mirColS(0), filterColS(0), iorS(0), filterCol(filtC), specRefCol(srcol), absorb(false), disperse(false),
-		fakeShadow(fakeS), dispersion_power(disp_pow), mCastShadows(bCastShadows)
+		fakeShadow(fakeS), dispersion_power(disp_pow), mVisibility(eVisibility)
 {
 	ior=IOR;
 	bsdfFlags = BSDF_ALL_SPECULAR;
@@ -312,7 +312,8 @@ material_t* glassMat_t::factory(paraMap_t &params, std::list< paraMap_t > &param
 	color_t filtCol(1.f), absorp(1.f), srCol(1.f);
 	const std::string *name=0;
 	bool fake_shad = false;
-	bool bCastShadows = true;
+	std::string sVisibility = "normal";
+	visibility_t visibility = NORMAL_VISIBLE;
 	
 	params.getParam("IOR", IOR);
 	params.getParam("filter_color", filtCol);
@@ -320,8 +321,16 @@ material_t* glassMat_t::factory(paraMap_t &params, std::list< paraMap_t > &param
 	params.getParam("mirror_color", srCol);
 	params.getParam("dispersion_power", disp_power);
 	params.getParam("fake_shadows", fake_shad);
-	params.getParam("cast_shadows",     bCastShadows);
-	glassMat_t *mat = new glassMat_t(IOR, filt*filtCol + color_t(1.f-filt), srCol, disp_power, fake_shad, bCastShadows);
+	params.getParam("visibility", sVisibility);
+	
+	if(sVisibility == "normal") visibility = NORMAL_VISIBLE;
+	else if(sVisibility == "no_shadows") visibility = VISIBLE_NO_SHADOWS;
+	else if(sVisibility == "shadow_only") visibility = INVISIBLE_SHADOWS_ONLY;
+	else if(sVisibility == "invisible") visibility = INVISIBLE;
+	else visibility = NORMAL_VISIBLE;
+
+	glassMat_t *mat = new glassMat_t(IOR, filt*filtCol + color_t(1.f-filt), srCol, disp_power, fake_shad, visibility);
+	
 	if( params.getParam("absorption", absorp) )
 	{
 		double dist=1.f;

--- a/src/materials/shinydiffuse.cc
+++ b/src/materials/shinydiffuse.cc
@@ -5,10 +5,10 @@
 
 __BEGIN_YAFRAY
 
-shinyDiffuseMat_t::shinyDiffuseMat_t(const color_t &diffuseColor, const color_t &mirrorColor, float diffuseStrength, float transparencyStrength, float translucencyStrength, float mirrorStrength, float emitStrength, float transmitFilterStrength, bool bCastShadows):
+shinyDiffuseMat_t::shinyDiffuseMat_t(const color_t &diffuseColor, const color_t &mirrorColor, float diffuseStrength, float transparencyStrength, float translucencyStrength, float mirrorStrength, float emitStrength, float transmitFilterStrength, visibility_t eVisibility):
             mIsTransparent(false), mIsTranslucent(false), mIsMirror(false), mIsDiffuse(false), mHasFresnelEffect(false),
             mDiffuseShader(0), mBumpShader(0), mTransparencyShader(0), mTranslucencyShader(0), mMirrorShader(0), mMirrorColorShader(0), mSigmaOrenShader(0), mDiffuseReflShader(0), iorS(0), mDiffuseColor(diffuseColor), mMirrorColor(mirrorColor),
-            mMirrorStrength(mirrorStrength), mTransparencyStrength(transparencyStrength), mTranslucencyStrength(translucencyStrength), mDiffuseStrength(diffuseStrength), mTransmitFilterStrength(transmitFilterStrength), mUseOrenNayar(false), nBSDF(0), mCastShadows(bCastShadows)
+            mMirrorStrength(mirrorStrength), mTransparencyStrength(transparencyStrength), mTranslucencyStrength(translucencyStrength), mDiffuseStrength(diffuseStrength), mTransmitFilterStrength(transmitFilterStrength), mUseOrenNayar(false), nBSDF(0), mVisibility(eVisibility)
 {
     mEmitColor = emitStrength * diffuseColor;
     mEmitStrength = emitStrength;
@@ -557,7 +557,8 @@ material_t* shinyDiffuseMat_t::factory(paraMap_t &params, std::list<paraMap_t> &
     float mirrorStrength=0.f;
     float emitStrength = 0.f;
     bool hasFresnelEffect=false;
-    bool bCastShadows=true;
+    std::string sVisibility = "normal";
+	visibility_t visibility = NORMAL_VISIBLE;
     float IOR = 1.33f;
     double transmitFilterStrength=1.0;
 
@@ -571,10 +572,16 @@ material_t* shinyDiffuseMat_t::factory(paraMap_t &params, std::list<paraMap_t> &
     params.getParam("IOR",              IOR);
     params.getParam("fresnel_effect",   hasFresnelEffect);
     params.getParam("transmit_filter",  transmitFilterStrength);
-    params.getParam("cast_shadows",     bCastShadows);
+    params.getParam("visibility",       sVisibility);
+	
+	if(sVisibility == "normal") visibility = NORMAL_VISIBLE;
+	else if(sVisibility == "no_shadows") visibility = VISIBLE_NO_SHADOWS;
+	else if(sVisibility == "shadow_only") visibility = INVISIBLE_SHADOWS_ONLY;
+	else if(sVisibility == "invisible") visibility = INVISIBLE;
+	else visibility = NORMAL_VISIBLE;
 
     // !!remember to put diffuse multiplier in material itself!
-    shinyDiffuseMat_t *mat = new shinyDiffuseMat_t(diffuseColor, mirrorColor, diffuseStrength, transparencyStrength, translucencyStrength, mirrorStrength, emitStrength, transmitFilterStrength, bCastShadows);
+    shinyDiffuseMat_t *mat = new shinyDiffuseMat_t(diffuseColor, mirrorColor, diffuseStrength, transparencyStrength, translucencyStrength, mirrorStrength, emitStrength, transmitFilterStrength, visibility);
 
     if(hasFresnelEffect)
     {

--- a/src/yafraycore/kdtree.cc
+++ b/src/yafraycore/kdtree.cc
@@ -748,10 +748,11 @@ bool triKdTree_t::Intersect(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFLO
 		if (nPrimitives == 1)
 		{
 			triangle_t *mp = currNode->onePrimitive;
+			const material_t *mat = mp->getMaterial();
 
 			if (mp->intersect(ray, &t_hit, tempData))
 			{
-				if(t_hit < Z && t_hit >= ray.tmin)
+				if(t_hit < Z && t_hit >= ray.tmin && (mat->getVisibility() == NORMAL_VISIBLE || mat->getVisibility() == VISIBLE_NO_SHADOWS) )
 				{
 					Z = t_hit;
 					*tr = mp;
@@ -770,7 +771,9 @@ bool triKdTree_t::Intersect(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFLO
 
 				if (mp->intersect(ray, &t_hit, tempData))
 				{
-					if(t_hit < Z && t_hit >= ray.tmin)
+					const material_t *mat = mp->getMaterial();
+					
+					if(t_hit < Z && t_hit >= ray.tmin && (mat->getVisibility() == NORMAL_VISIBLE || mat->getVisibility() == VISIBLE_NO_SHADOWS) )
 					{
 						Z = t_hit;
 						*tr = mp;
@@ -896,7 +899,7 @@ bool triKdTree_t::IntersectS(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFL
 			if (mp->intersect(ray, &t_hit, bary))
 			{
 				const material_t *mat = mp->getMaterial();
-				if(t_hit < dist && t_hit >= shadow_bias && mat->castShadows() ) // '>=' ?
+				if(t_hit < dist && t_hit >= shadow_bias && (mat->getVisibility() == NORMAL_VISIBLE || mat->getVisibility() == INVISIBLE_SHADOWS_ONLY) ) // '>=' ?
 				{
 					*tr = mp;
 					return true;
@@ -912,7 +915,7 @@ bool triKdTree_t::IntersectS(const ray_t &ray, PFLOAT dist, triangle_t **tr, PFL
 				if (mp->intersect(ray, &t_hit, bary))
 				{
 					const material_t *mat = mp->getMaterial();
-					if(t_hit < dist && t_hit >= shadow_bias && mat->castShadows() )
+					if(t_hit < dist && t_hit >= shadow_bias && (mat->getVisibility() == NORMAL_VISIBLE || mat->getVisibility() == INVISIBLE_SHADOWS_ONLY) )
 					{
 						*tr = mp;
 						return true;
@@ -1036,10 +1039,9 @@ bool triKdTree_t::IntersectTS(renderState_t &state, const ray_t &ray, int maxDep
 			triangle_t *mp = currNode->onePrimitive;
 			if (mp->intersect(ray, &t_hit, bary))
 			{
-				if(t_hit < dist && t_hit >= shadow_bias ) // '>=' ?
+				const material_t *mat = mp->getMaterial();
+				if(t_hit < dist && t_hit >= shadow_bias && (mat->getVisibility() == NORMAL_VISIBLE || mat->getVisibility() == INVISIBLE_SHADOWS_ONLY) ) // '>=' ?
 				{
-					const material_t *mat = mp->getMaterial();
-					if(!mat->castShadows() ) return false;
 					if(!mat->isTransparent() ) return true;
 					
 					if(filtered.insert(mp).second)
@@ -1062,10 +1064,9 @@ bool triKdTree_t::IntersectTS(renderState_t &state, const ray_t &ray, int maxDep
 				triangle_t *mp = prims[i];
 				if (mp->intersect(ray, &t_hit, bary))
 				{
-					if(t_hit < dist && t_hit >= shadow_bias)
+					const material_t *mat = mp->getMaterial();
+					if(t_hit < dist && t_hit >= shadow_bias && (mat->getVisibility() == NORMAL_VISIBLE || mat->getVisibility() == INVISIBLE_SHADOWS_ONLY) )
 					{
-						const material_t *mat = mp->getMaterial();
-						if(!mat->castShadows() ) return false;
 						if(!mat->isTransparent() ) return true;
 
 						if(filtered.insert(mp).second)


### PR DESCRIPTION
I've added a parameter to control which lights cast shadows and which ones do not.

Also, I've removed the recently added cast_shadow parameter and replaced it by a "visibility" parameter (enum type) so we can control the material visibility and shadow at the same time. The visibility option (in the material advanced settings) will have these possible values (per-material):

'normal' (default): Normal - Normal visibility - visible casting shadows.
'no_shadows': No shadows - visible but not casting shadows.
'shadow_only': Shadows only - invisible but casting shadows.
'invisible': Invisible: totally invisible material.

 Changes to be committed:
    modified:   include/core_api/light.h
    modified:   include/core_api/material.h
    modified:   include/lights/arealight.h
    modified:   include/lights/bgportallight.h
    modified:   include/lights/meshlight.h
    modified:   include/materials/blendmat.h
    modified:   include/materials/maskmat.h
    modified:   include/materials/roughglass.h
    modified:   include/materials/shinydiff.h
    modified:   include/yafray_constants.h
    modified:   src/lights/arealight.cc
    modified:   src/lights/bgportallight.cc
    modified:   src/lights/directional.cc
    modified:   src/lights/iesLight.cc
    modified:   src/lights/meshlight.cc
    modified:   src/lights/pointlight.cc
    modified:   src/lights/spherelight.cc
    modified:   src/lights/spotlight.cc
    modified:   src/lights/sunlight.cc
    modified:   src/materials/blend.cc
    modified:   src/materials/coatedglossy.cc
    modified:   src/materials/glass.cc
    modified:   src/materials/glossy.cc
    modified:   src/materials/glossy2.cc
    modified:   src/materials/mask.cc
    modified:   src/materials/roughglass.cc
    modified:   src/materials/shinydiffuse.cc
    modified:   src/yafraycore/kdtree.cc
    modified:   src/yafraycore/mcintegrator.cc
